### PR TITLE
Fixing highest_channel_number when no channels exist

### DIFF
--- a/dizqueTV/dizquetv.py
+++ b/dizqueTV/dizquetv.py
@@ -572,7 +572,8 @@ class API:
         :return: Int number of the highest active channel
         :rtype: int
         """
-        return max(self.channel_numbers)
+        # if no channels exist, self.channel_numbers is an empty list
+        return max(self.channel_numbers + [0])
 
     @property
     def lowest_channel_number(self) -> int:


### PR DESCRIPTION
When no channels exist, highest_channel_number would attempt
to return max([]) which causes an exception. Simple fix is to
return max() of the joining of the channel_numbers and [0]